### PR TITLE
Add <cmath> header to fix compilation error

### DIFF
--- a/src/jbms/benchmark.hpp
+++ b/src/jbms/benchmark.hpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include <boost/range/size.hpp>
+#include <cmath>
 
 //#define JBMS_BENCHMARK_DEBUG_OUTPUT
 


### PR DESCRIPTION
The code uses std::sqrt, std::floor, and std::ceil for various operations, but doesn't include <cmath>, which is required for these functions to be in the proper namespace.